### PR TITLE
Add docker image and workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+name: Build docker image
+
+on:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    name: build and publish capture image
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check Out Repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64, linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: RUST_BACKTRACE=1
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1.68.0 AS chef
+WORKDIR app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+
+# Ensure working C compile setup (not installed by default in arm64 images)
+RUN apt update && apt install build-essential -y
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+RUN cargo build --release --bin capture
+
+FROM debian:bullseye-20230320-slim AS runtime
+
+WORKDIR app
+
+USER nobody
+
+COPY --from=builder /app/target/release/capture /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/capture"]


### PR DESCRIPTION
Our docker image is built using Cargo Chef

This is a pretty standard tool for Rust docker images - it'll just ensure that we don't end up rebuilding dependencies all the time, by building a minimal docker layer of just the deps.

Otherwise, add a workflow to trigger this