### PR TITLE
drop the unused site_url field

### DIFF
--- a/capture/src/capture.rs
+++ b/capture/src/capture.rs
@@ -94,7 +94,6 @@ pub fn process_single_event(
         uuid: event.uuid.unwrap_or_else(uuid_v7),
         distinct_id: distinct_id.to_string(),
         ip: context.client_ip.clone(),
-        site_url: String::new(),
         data: String::from("hallo I am some data 😊"),
         now: context.now.clone(),
         sent_at: context.sent_at,

--- a/capture/src/event.rs
+++ b/capture/src/event.rs
@@ -121,7 +121,6 @@ pub struct ProcessedEvent {
     pub uuid: Uuid,
     pub distinct_id: String,
     pub ip: String,
-    pub site_url: String,
     pub data: String,
     pub now: String,
     #[serde(with = "time::serde::rfc3339::option")]

--- a/capture/tests/django_compat.rs
+++ b/capture/tests/django_compat.rs
@@ -140,7 +140,10 @@ async fn it_matches_django_capture_behaviour() -> anyhow::Result<()> {
                     OffsetDateTime::parse(value.as_str().expect("empty"), &Iso8601::DEFAULT)?;
                 *value = Value::String(sent_at.format(&Rfc3339)?)
             }
-
+            if let Some(object) = expected.as_object_mut() {
+                // site_url is unused in the pipeline now, let's drop it
+                object.remove("site_url");
+            }
             let match_config = assert_json_diff::Config::new(assert_json_diff::CompareMode::Strict);
             if let Err(e) =
                 assert_json_matches_no_panic(&json!(expected), &json!(message), match_config)


### PR DESCRIPTION
The [capture.py code](https://github.com/PostHog/posthog/blob/f438e59d8ab7d5cce7a33e5fdf9f79ff54837992/posthog/api/capture.py#L391) indicates it's unused and vestigial, and a code search on the monolith does not return any useful use of that field. It's not in the CH schema anymore, so it's copied-over by plugin-server but dropped by CH.