### PR TITLE
fill the data field in analytics events

### DIFF
--- a/capture/src/api.rs
+++ b/capture/src/api.rs
@@ -34,6 +34,8 @@ pub enum CaptureError {
 
     #[error("request holds no event")]
     EmptyBatch,
+    #[error("event submitted with an empty event name")]
+    MissingEventName,
     #[error("event submitted without a distinct_id")]
     MissingDistinctId,
 
@@ -58,6 +60,7 @@ impl IntoResponse for CaptureError {
             CaptureError::RequestDecodingError(_)
             | CaptureError::RequestParsingError(_)
             | CaptureError::EmptyBatch
+            | CaptureError::MissingEventName
             | CaptureError::MissingDistinctId
             | CaptureError::EventTooBig
             | CaptureError::NonRetryableSinkError => (StatusCode::BAD_REQUEST, self.to_string()),

--- a/capture/src/capture.rs
+++ b/capture/src/capture.rs
@@ -89,12 +89,20 @@ pub fn process_single_event(
             _ => return Err(CaptureError::MissingDistinctId),
         },
     };
+    if event.event.is_empty() {
+        return Err(CaptureError::MissingEventName);
+    }
+
+    let data = serde_json::to_string(&event).map_err(|e| {
+        tracing::error!("failed to encode data field: {}", e);
+        CaptureError::NonRetryableSinkError
+    })?;
 
     Ok(ProcessedEvent {
         uuid: event.uuid.unwrap_or_else(uuid_v7),
         distinct_id: distinct_id.to_string(),
         ip: context.client_ip.clone(),
-        data: String::from("hallo I am some data 😊"),
+        data,
         now: context.now.clone(),
         sent_at: context.sent_at,
         token: context.token.clone(),
@@ -158,6 +166,10 @@ mod tests {
                 uuid: None,
                 event: String::new(),
                 properties: HashMap::new(),
+                timestamp: None,
+                offset: None,
+                set: Default::default(),
+                set_once: Default::default(),
             },
             RawEvent {
                 token: None,
@@ -165,6 +177,10 @@ mod tests {
                 uuid: None,
                 event: String::new(),
                 properties: HashMap::from([(String::from("token"), json!("hello"))]),
+                timestamp: None,
+                offset: None,
+                set: Default::default(),
+                set_once: Default::default(),
             },
         ];
 
@@ -181,6 +197,10 @@ mod tests {
                 uuid: None,
                 event: String::new(),
                 properties: HashMap::new(),
+                timestamp: None,
+                offset: None,
+                set: Default::default(),
+                set_once: Default::default(),
             },
             RawEvent {
                 token: None,
@@ -188,6 +208,10 @@ mod tests {
                 uuid: None,
                 event: String::new(),
                 properties: HashMap::from([(String::from("token"), json!("goodbye"))]),
+                timestamp: None,
+                offset: None,
+                set: Default::default(),
+                set_once: Default::default(),
             },
         ];
 

--- a/capture/src/event.rs
+++ b/capture/src/event.rs
@@ -37,12 +37,25 @@ pub struct EventFormData {
 
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct RawEvent {
-    #[serde(alias = "$token", alias = "api_key")]
+    #[serde(
+        alias = "$token",
+        alias = "api_key",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub distinct_id: Option<String>,
     pub uuid: Option<Uuid>,
     pub event: String,
-    pub properties: HashMap<String, Value>,
+    pub properties: HashMap<String, Value>, // TOOD: make optional?
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>, // Passed through if provided, parsed by ingestion
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<i64>, // Passed through if provided, parsed by ingestion
+    #[serde(rename = "$set", skip_serializing_if = "Option::is_none")]
+    pub set: Option<HashMap<String, Value>>,
+    #[serde(rename = "$set_once", skip_serializing_if = "Option::is_none")]
+    pub set_once: Option<HashMap<String, Value>>,
 }
 
 #[derive(Deserialize)]

--- a/capture/src/event.rs
+++ b/capture/src/event.rs
@@ -47,7 +47,8 @@ pub struct RawEvent {
     pub distinct_id: Option<String>,
     pub uuid: Option<Uuid>,
     pub event: String,
-    pub properties: HashMap<String, Value>, // TOOD: make optional?
+    #[serde(default)]
+    pub properties: HashMap<String, Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>, // Passed through if provided, parsed by ingestion
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,14 +65,14 @@ enum RawRequest {
     /// Batch of events
     Batch(Vec<RawEvent>),
     /// Single event
-    One(RawEvent),
+    One(Box<RawEvent>),
 }
 
 impl RawRequest {
     pub fn events(self) -> Vec<RawEvent> {
         match self {
             RawRequest::Batch(events) => events,
-            RawRequest::One(event) => vec![event],
+            RawRequest::One(event) => vec![*event],
         }
     }
 }


### PR DESCRIPTION
This PR brings payload equivalence with capture.py for payloads sourced from the latest posthog-js version:

-  check that the event name is not empty
- add the missing optional `timestamp`, `offset`, `$set` and `$set_once` toplevel fields
- serialize the RawEvent in the output `data` field
- set the `skip_serializing_if = "Option::is_none"` serde annotation where relevant
- make `it_matches_django_capture_behaviour` unmarshall both `data` and compare the object instead of the byes
- un-ignore `it_matches_django_capture_behaviour` as it now passes 🎉 
- allow to ommit the`RawEvent.properties` field in requests, default to an empty dict if not set
