### PR TITLE
add more metrics

### DIFF
--- a/capture/src/billing_limits.rs
+++ b/capture/src/billing_limits.rs
@@ -51,7 +51,7 @@ pub struct BillingLimiter {
     limited: Arc<RwLock<HashSet<String>>>,
     redis: Arc<dyn Client + Send + Sync>,
     interval: Duration,
-    updated: Arc<RwLock<time::OffsetDateTime>>,
+    updated: Arc<RwLock<OffsetDateTime>>,
 }
 
 impl BillingLimiter {

--- a/capture/src/prometheus.rs
+++ b/capture/src/prometheus.rs
@@ -10,12 +10,17 @@ pub fn setup_metrics_recorder() -> PrometheusHandle {
     const EXPONENTIAL_SECONDS: &[f64] = &[
         0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
     ];
+    const BATCH_SIZES: &[f64] = &[
+        1.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 750.0, 1000.0,
+    ];
 
     PrometheusBuilder::new()
         .set_buckets_for_metric(
             Matcher::Full("http_requests_duration_seconds".to_string()),
             EXPONENTIAL_SECONDS,
         )
+        .unwrap()
+        .set_buckets_for_metric(Matcher::Suffix("_batch_size".to_string()), BATCH_SIZES)
         .unwrap()
         .install_recorder()
         .unwrap()


### PR DESCRIPTION
Port the metrics capture.py currently emits, and add another about the number of events per request, to confirm that posthog-js's batching about be improved ^^