### PR TITLE
add envconfig to parse envvars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "capture",
+ "envconfig",
  "time",
  "tokio",
  "tracing",
@@ -377,6 +378,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "envconfig"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea81cc7e21f55a9d9b1efb6816904978d0bfbe31a50347cb24b2e75564bcac9b"
+dependencies = [
+ "envconfig_derive",
+]
+
+[[package]]
+name = "envconfig_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfca278e5f84b45519acaaff758ebfa01f18e96998bc24b8f1b722dd804b9bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/capture-server/Cargo.toml
+++ b/capture-server/Cargo.toml
@@ -10,3 +10,4 @@ tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
 time = { workspace = true }
+envconfig = "0.10.0"


### PR DESCRIPTION
Using `envconfig` as it's good enough for what we need (no need for layered configs), and its error messages are more graceful than the ones thrown by `config`.

It would be easy to switch out to a more featureful crate later.