### PR TITLE
kafka: check reachability + collect metrics

### DIFF
--- a/capture-server/src/main.rs
+++ b/capture-server/src/main.rs
@@ -35,6 +35,9 @@ async fn shutdown() {
 
 #[tokio::main]
 async fn main() {
+    // initialize tracing
+    tracing_subscriber::fmt::init();
+
     let config = Config::init_from_env().expect("Invalid configuration:");
 
     let redis_client =
@@ -62,9 +65,6 @@ async fn main() {
             true,
         )
     };
-
-    // initialize tracing
-    tracing_subscriber::fmt::init();
 
     // run our app with hyper
     // `axum::Server` is a re-export of `hyper::Server`

--- a/capture-server/src/main.rs
+++ b/capture-server/src/main.rs
@@ -13,6 +13,7 @@ struct Config {
     #[envconfig(default = "127.0.0.1:3000")]
     address: SocketAddr,
     redis_url: String,
+
     kafka_hosts: String,
     kafka_topic: String,
 }

--- a/capture/src/sink.rs
+++ b/capture/src/sink.rs
@@ -6,7 +6,6 @@ use crate::api::CaptureError;
 use rdkafka::config::ClientConfig;
 use rdkafka::error::RDKafkaErrorCode;
 use rdkafka::producer::future_producer::{FutureProducer, FutureRecord};
-use tracing::debug;
 
 use crate::event::ProcessedEvent;
 
@@ -44,8 +43,6 @@ struct KafkaContext;
 
 impl rdkafka::ClientContext for KafkaContext {
     fn stats(&self, stats: rdkafka::Statistics) {
-        debug!("Client stats: {:?}", &stats);
-
         gauge!("capture_kafka_callback_queue_depth", stats.replyq as f64);
         gauge!("capture_kafka_producer_queue_depth", stats.msg_cnt as f64);
         gauge!(

--- a/capture/src/sink.rs
+++ b/capture/src/sink.rs
@@ -1,11 +1,12 @@
 use async_trait::async_trait;
-use metrics::{counter, histogram};
+use metrics::{absolute_counter, counter, gauge, histogram};
 use tokio::task::JoinSet;
 
 use crate::api::CaptureError;
 use rdkafka::config::ClientConfig;
 use rdkafka::error::RDKafkaErrorCode;
 use rdkafka::producer::future_producer::{FutureProducer, FutureRecord};
+use tracing::debug;
 
 use crate::event::ProcessedEvent;
 
@@ -39,17 +40,75 @@ impl EventSink for PrintSink {
     }
 }
 
+struct KafkaContext;
+
+impl rdkafka::ClientContext for KafkaContext {
+    fn stats(&self, stats: rdkafka::Statistics) {
+        debug!("Client stats: {:?}", &stats);
+
+        gauge!("capture_kafka_callback_queue_depth", stats.replyq as f64);
+        gauge!("capture_kafka_producer_queue_depth", stats.msg_cnt as f64);
+        gauge!(
+            "capture_kafka_producer_queue_depth_limit",
+            stats.msg_max as f64
+        );
+        gauge!("capture_kafka_producer_queue_bytes", stats.msg_max as f64);
+        gauge!(
+            "capture_kafka_producer_queue_bytes_limit",
+            stats.msg_size_max as f64
+        );
+
+        for (topic, stats) in stats.topics {
+            gauge!(
+                "capture_kafka_produce_avg_batch_size_bytes",
+                stats.batchsize.avg as f64,
+                "topic" => topic.clone()
+            );
+            gauge!(
+                "capture_kafka_produce_avg_batch_size_events",
+                stats.batchcnt.avg as f64,
+                "topic" => topic
+            );
+        }
+
+        for (_, stats) in stats.brokers {
+            let id_string = format!("{}", stats.nodeid);
+            gauge!(
+                "capture_kafka_broker_requests_pending",
+                stats.outbuf_cnt as f64,
+                "broker" => id_string.clone()
+            );
+            gauge!(
+                "capture_kafka_broker_responses_awaiting",
+                stats.waitresp_cnt as f64,
+                "broker" => id_string.clone()
+            );
+            absolute_counter!(
+                "capture_kafka_broker_tx_errors_total",
+                stats.txerrs,
+                "broker" => id_string.clone()
+            );
+            absolute_counter!(
+                "capture_kafka_broker_rx_errors_total",
+                stats.rxerrs,
+                "broker" => id_string
+            );
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct KafkaSink {
-    producer: FutureProducer,
+    producer: FutureProducer<KafkaContext>,
     topic: String,
 }
 
 impl KafkaSink {
     pub fn new(topic: String, brokers: String) -> anyhow::Result<KafkaSink> {
-        let producer: FutureProducer = ClientConfig::new()
+        let producer: FutureProducer<KafkaContext> = ClientConfig::new()
             .set("bootstrap.servers", &brokers)
-            .create()?;
+            .set("statistics.interval.ms", "10000")
+            .create_with_context(KafkaContext)?;
 
         Ok(KafkaSink { producer, topic })
     }
@@ -57,7 +116,7 @@ impl KafkaSink {
 
 impl KafkaSink {
     async fn kafka_send(
-        producer: FutureProducer,
+        producer: FutureProducer<KafkaContext>,
         topic: String,
         event: ProcessedEvent,
     ) -> Result<(), CaptureError> {


### PR DESCRIPTION
- Make sure capture does not start if the Kafka brokers are unreachable. We'll want to tie that to a readiness probe later instead.
- Collect kafka producer metrics every 10 seconds:

```
capture_kafka_broker_tx_errors_total{broker="1"} 0
capture_kafka_broker_tx_errors_total{broker="-1"} 0
capture_kafka_broker_rx_errors_total{broker="-1"} 0
capture_kafka_broker_rx_errors_total{broker="1"} 0
capture_kafka_producer_queue_bytes 100000
capture_kafka_producer_queue_bytes_limit 1073741824
capture_kafka_producer_queue_depth_limit 100000
capture_kafka_produce_avg_batch_size_bytes{topic="events_plugin_ingestion"} 2036
capture_kafka_callback_queue_depth 0
capture_kafka_broker_requests_pending{broker="-1"} 0
capture_kafka_broker_requests_pending{broker="1"} 0
capture_kafka_producer_queue_depth 1
capture_kafka_produce_avg_batch_size_events{topic="events_plugin_ingestion"} 1
capture_kafka_broker_responses_awaiting{broker="-1"} 0
capture_kafka_broker_responses_awaiting{broker="1"} 0
```