### PR TITLE
add cors support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1.0.96"
 governor = "0.5.1"
 tower_governor = "0.0.4"
 time = { version = "0.3.20", features = ["formatting", "macros", "parsing", "serde"] }
-tower-http = { version = "0.4.0", features = ["trace"] }
+tower-http = { version = "0.4.0", features = ["cors", "trace"] }
 bytes = "1"
 anyhow = "1.0"
 flate2 = "1.0"

--- a/capture/src/capture.rs
+++ b/capture/src/capture.rs
@@ -104,6 +104,12 @@ pub async fn event(
     }))
 }
 
+pub async fn options() -> Result<Json<CaptureResponse>, CaptureError> {
+    Ok(Json(CaptureResponse {
+        status: CaptureResponseCode::Ok,
+    }))
+}
+
 pub fn process_single_event(
     event: &RawEvent,
     context: &ProcessingContext,


### PR DESCRIPTION
- Mirror the permissive CORS settings in https://github.com/PostHog/posthog/posthog/api/capture.py, using tower's cors layer
- Instead of allowing a given number of headers, I'm setting the middleware to allow all headers
- Add a handler for `OPTIONS` requests, like capture.py has