### PR TITLE
cors: enable allow_credentials

### DIFF
--- a/capture/src/router.rs
+++ b/capture/src/router.rs
@@ -6,7 +6,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+use tower_http::cors::{AllowHeaders, AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 
 use crate::{billing_limits::BillingLimiter, capture, redis::Client, sink, time::TimeSource};
@@ -47,7 +47,8 @@ pub fn router<
     // and reverse proxies might send funky headers.
     let cors = CorsLayer::new()
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
-        .allow_headers(Any)
+        .allow_headers(AllowHeaders::mirror_request())
+        .allow_credentials(true)
         .allow_origin(AllowOrigin::mirror_request());
 
     let router = Router::new()


### PR DESCRIPTION
Fix the following error: 
> Access to XMLHttpRequest at 'https://app.posthog.com/i/v0/e/?compression=gzip-js&ip=1&_=1699004313770&ver=1.88.1&retry_count=1&' from origin 'https://eu.posthog.com' has been blocked by CORS policy: The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
