### PR TITLE
kafka sink: expose more rdkafka settings

### DIFF
--- a/capture/src/config.rs
+++ b/capture/src/config.rs
@@ -11,7 +11,18 @@ pub struct Config {
     pub redis_url: String,
     #[envconfig(default = "true")]
     pub export_prometheus: bool,
+    #[envconfig(nested = true)]
+    pub kafka: KafkaConfig,
+}
 
+#[derive(Envconfig, Clone)]
+pub struct KafkaConfig {
+    #[envconfig(default = "20")]
+    pub kafka_producer_linger_ms: u32, // Maximum time between producer batches during low traffic
+    #[envconfig(default = "400")]
+    pub kafka_producer_queue_mib: u32, // Size of the in-memory producer queue in mebibytes
+    #[envconfig(default = "none")]
+    pub kafka_compression_codec: String, // none, gzip, snappy, lz4, zstd
     pub kafka_hosts: String,
     pub kafka_topic: String,
     #[envconfig(default = "false")]

--- a/capture/src/server.rs
+++ b/capture/src/server.rs
@@ -28,9 +28,7 @@ where
             config.export_prometheus,
         )
     } else {
-        let sink =
-            sink::KafkaSink::new(config.kafka_topic, config.kafka_hosts, config.kafka_tls).unwrap();
-
+        let sink = sink::KafkaSink::new(config.kafka).unwrap();
         router::router(
             crate::time::SystemTime {},
             sink,


### PR DESCRIPTION
Allow to configure a few kafka parameters affecting performance and cost:

- `linger.ms`, using a default of 20ms (higher than rdk's 5ms default), to reduce MSK pressure
- `queue.buffering.max.kbytes`, doing to 400MiB down from rdk's 1GiB default, to avoid OOMing
- `compression.codec`, leaving the default to `none` for now, will run it with `gzip` on dev and make sure it does not break plugin-server, then change that default

There'll be more to come, but it's a good start.