### PR TITLE
cors: allow every origin hostname, in case host header is rewritten

### DIFF
--- a/capture/src/router.rs
+++ b/capture/src/router.rs
@@ -51,7 +51,7 @@ pub fn router<
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
         .allow_headers(AllowHeaders::mirror_request())
         .allow_credentials(true)
-        .allow_origin(AllowOrigin::mirror_request());
+        .allow_origin(AllowOrigin::any());
 
     let router = Router::new()
         // TODO: use NormalizePathLayer::trim_trailing_slash


### PR DESCRIPTION
Our [reverse proxy recommendations](https://posthog.com/docs/advanced/proxy) ask to rewrite the `Host` header, so `AllowOrigin::mirror_request()` returns `app.posthog.com` instead of the browser-facing domain, which makes CORS check fail.