### PR TITLE
tests: add integration test for billing limits

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: |
-         ~/.cargo/registry
+          ~/.cargo/registry
           ~/.cargo/git
           target
         key: ${ runner.os }-cargo-debug-${{ hashFiles('**/Cargo.lock') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "opentelemetry_sdk",
  "rand",
  "rdkafka",
+ "redis",
  "reqwest",
  "serde_json",
  "time",
@@ -307,12 +308,6 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
-
-[[package]]
-name = "crc16"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
@@ -1570,14 +1565,10 @@ dependencies = [
  "async-trait",
  "bytes",
  "combine",
- "crc16",
- "futures",
  "futures-util",
  "itoa",
- "log",
  "percent-encoding",
  "pin-project-lite",
- "rand",
  "ryu",
  "sha1_smol",
  "socket2 0.4.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ metrics = "0.21.1"
 metrics-exporter-prometheus = "0.12.1"
 thiserror = "1.0.48"
 envconfig = "0.10.0"
+redis = { version="0.23.3", features=["tokio-comp"] }

--- a/capture-server/Cargo.toml
+++ b/capture-server/Cargo.toml
@@ -22,6 +22,7 @@ assert-json-diff =  { workspace = true }
 futures = "0.3.29"
 once_cell = "1.18.0"
 rand = { workspace = true }
+redis = { workspace = true }
 rdkafka = { workspace = true }
 reqwest = "0.11.22"
 serde_json = { workspace = true }

--- a/capture-server/tests/events.rs
+++ b/capture-server/tests/events.rs
@@ -1,9 +1,11 @@
 use std::num::NonZeroU32;
+use std::ops::Add;
 
 use anyhow::Result;
 use assert_json_diff::assert_json_include;
 use reqwest::StatusCode;
 use serde_json::json;
+use time::{Duration, OffsetDateTime};
 
 use crate::common::*;
 mod common;
@@ -14,7 +16,7 @@ async fn it_captures_one_event() -> Result<()> {
     let token = random_string("token", 16);
     let distinct_id = random_string("id", 16);
     let topic = EphemeralTopic::new().await;
-    let server = ServerHandle::for_topic(&topic);
+    let server = ServerConfig::default().with(&topic).start();
 
     let event = json!({
         "token": token,
@@ -44,7 +46,7 @@ async fn it_captures_a_batch() -> Result<()> {
     let distinct_id2 = random_string("id", 16);
 
     let topic = EphemeralTopic::new().await;
-    let server = ServerHandle::for_topic(&topic);
+    let server = ServerConfig::default().with(&topic).start();
 
     let event = json!([{
         "token": token,
@@ -84,13 +86,12 @@ async fn it_is_limited_with_burst() -> Result<()> {
     let distinct_id = random_string("id", 16);
 
     let topic = EphemeralTopic::new().await;
-
-    let mut config = DEFAULT_CONFIG.clone();
-    config.kafka.kafka_topic = topic.topic_name().to_string();
-    config.burst_limit = NonZeroU32::new(2).unwrap();
-    config.per_second_limit = NonZeroU32::new(1).unwrap();
-
-    let server = ServerHandle::for_config(config);
+    let server = ServerConfig::new(|config| {
+        config.burst_limit = NonZeroU32::new(2).unwrap();
+        config.per_second_limit = NonZeroU32::new(1).unwrap();
+    })
+    .with(&topic)
+    .start();
 
     let event = json!([{
         "token": token,
@@ -133,13 +134,12 @@ async fn it_does_not_partition_limit_different_ids() -> Result<()> {
     let distinct_id2 = random_string("id", 16);
 
     let topic = EphemeralTopic::new().await;
-
-    let mut config = DEFAULT_CONFIG.clone();
-    config.kafka.kafka_topic = topic.topic_name().to_string();
-    config.burst_limit = NonZeroU32::new(1).unwrap();
-    config.per_second_limit = NonZeroU32::new(1).unwrap();
-
-    let server = ServerHandle::for_config(config);
+    let server = ServerConfig::new(|config| {
+        config.burst_limit = NonZeroU32::new(1).unwrap();
+        config.per_second_limit = NonZeroU32::new(1).unwrap();
+    })
+    .with(&topic)
+    .start();
 
     let event = json!([{
         "token": token,
@@ -162,6 +162,92 @@ async fn it_does_not_partition_limit_different_ids() -> Result<()> {
     assert_eq!(
         topic.next_message_key()?.unwrap(),
         format!("{}:{}", token, distinct_id2)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn it_enforces_billing_limits() -> Result<()> {
+    setup_tracing();
+
+    let distinct_id = random_string("id", 16);
+    let topic = EphemeralTopic::new().await;
+    let redis = EphemeralRedis::new().await;
+
+    // team1 hit rate-limits for events, capture should drop
+    let token1 = random_string("token1", 16);
+    redis.add_billing_limit(
+        "events",
+        &token1,
+        OffsetDateTime::now_utc().add(Duration::hours(1)),
+    )?;
+
+    // team2 has no billing limit for events, allow input
+    let token2 = random_string("token2", 16);
+    redis.add_billing_limit(
+        "recordings",
+        &token2,
+        OffsetDateTime::now_utc().add(Duration::hours(1)),
+    )?;
+
+    // team3 was limited, but the new billing period started an hour ago, allow input
+    let token3 = random_string("token3", 16);
+    redis.add_billing_limit(
+        "events",
+        &token3,
+        OffsetDateTime::now_utc().add(Duration::hours(-1)),
+    )?;
+
+    let server = ServerConfig::default().with(&topic).with(&redis).start();
+
+    let res = server
+        .capture_events(
+            json!({
+                "token": token1,
+                "event": "NOK: should be dropped",
+                "distinct_id": distinct_id
+            })
+            .to_string(),
+        )
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let res = server
+        .capture_events(
+            json!({
+                "token": token2,
+                "event": "OK: no billing limit",
+                "distinct_id": distinct_id
+            })
+            .to_string(),
+        )
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    let res = server
+        .capture_events(
+            json!({
+                "token": token3,
+                "event": "OK: billing limit expired",
+                "distinct_id": distinct_id
+            })
+            .to_string(),
+        )
+        .await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    assert_json_include!(
+        actual: topic.next_event()?,
+        expected: json!({
+            "token": token2, // Message with token1 should not pass through
+        })
+    );
+    assert_json_include!(
+        actual: topic.next_event()?,
+        expected: json!({
+            "token": token3,
+        })
     );
 
     Ok(())

--- a/capture/Cargo.toml
+++ b/capture/Cargo.toml
@@ -29,7 +29,7 @@ rdkafka = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 thiserror = { workspace = true }
-redis = { version="0.23.3", features=["tokio-comp", "cluster", "cluster-async"] }
+redis = { workspace = true }
 envconfig = { workspace = true }
 dashmap = "5.5.3"
 

--- a/capture/src/config.rs
+++ b/capture/src/config.rs
@@ -11,7 +11,8 @@ pub struct Config {
     pub address: SocketAddr,
 
     pub redis_url: String,
-    pub redis_key_prefix: Option<String>,
+    pub redis_key_prefix: Option<String>, // Used for integration tests only
+
     pub otel_url: Option<String>,
 
     #[envconfig(default = "100")]

--- a/capture/src/config.rs
+++ b/capture/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub address: SocketAddr,
 
     pub redis_url: String,
+    pub redis_key_prefix: Option<String>,
     pub otel_url: Option<String>,
 
     #[envconfig(default = "100")]

--- a/capture/src/redis.rs
+++ b/capture/src/redis.rs
@@ -23,7 +23,7 @@ pub trait Client {
 
 pub struct RedisClient {
     client: redis::Client,
-    key_prefix: Option<String>
+    key_prefix: Option<String>,
 }
 
 impl RedisClient {

--- a/capture/src/server.rs
+++ b/capture/src/server.rs
@@ -18,7 +18,7 @@ where
     let liveness = HealthRegistry::new("liveness");
 
     let redis_client =
-        Arc::new(RedisClient::new(config.redis_url).expect("failed to create redis client"));
+        Arc::new(RedisClient::new(config.redis_url, config.redis_key_prefix).expect("failed to create redis client"));
 
     let billing = BillingLimiter::new(Duration::seconds(5), redis_client.clone())
         .expect("failed to create billing limiter");

--- a/capture/src/server.rs
+++ b/capture/src/server.rs
@@ -17,8 +17,10 @@ where
 {
     let liveness = HealthRegistry::new("liveness");
 
-    let redis_client =
-        Arc::new(RedisClient::new(config.redis_url, config.redis_key_prefix).expect("failed to create redis client"));
+    let redis_client = Arc::new(
+        RedisClient::new(config.redis_url, config.redis_key_prefix)
+            .expect("failed to create redis client"),
+    );
 
     let billing = BillingLimiter::new(Duration::seconds(5), redis_client.clone())
         .expect("failed to create billing limiter");


### PR DESCRIPTION
- Add a `redis_key_prefix` config and implement it in our redis wrapper
- Add `EphemeralRedis` to our integration tests helpers, deletes all subkeys on Drop
- Add `it_enforces_billing_limits` integration test