### PR TITLE
feat(overflow): add overflow_forced_keys envvar

### DIFF
--- a/capture-server/tests/common.rs
+++ b/capture-server/tests/common.rs
@@ -29,6 +29,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     redis_url: "redis://localhost:6379/".to_string(),
     burst_limit: NonZeroU32::new(5).unwrap(),
     per_second_limit: NonZeroU32::new(10).unwrap(),
+    overflow_forced_keys: None,
     kafka: KafkaConfig {
         kafka_producer_linger_ms: 0, // Send messages as soon as possible
         kafka_producer_queue_mib: 10,

--- a/capture/src/config.rs
+++ b/capture/src/config.rs
@@ -19,6 +19,8 @@ pub struct Config {
     #[envconfig(default = "1000")]
     pub burst_limit: NonZeroU32,
 
+    pub overflow_forced_keys: Option<String>, // Coma-delimited keys
+
     #[envconfig(nested = true)]
     pub kafka: KafkaConfig,
 

--- a/capture/src/partition_limits.rs
+++ b/capture/src/partition_limits.rs
@@ -7,6 +7,7 @@
 /// with a 429, we relax our ordering constraints and temporarily override the key, meaning the
 /// customers data will be spread across all partitions.
 use std::{num::NonZeroU32, sync::Arc};
+use std::collections::HashSet;
 
 use governor::{clock, state::keyed::DefaultKeyedStateStore, Quota, RateLimiter};
 
@@ -14,18 +15,24 @@ use governor::{clock, state::keyed::DefaultKeyedStateStore, Quota, RateLimiter};
 #[derive(Clone)]
 pub struct PartitionLimiter {
     limiter: Arc<RateLimiter<String, DefaultKeyedStateStore<String>, clock::DefaultClock>>,
+    forced_keys: HashSet<String>,
 }
 
 impl PartitionLimiter {
-    pub fn new(per_second: NonZeroU32, burst: NonZeroU32) -> Self {
+    pub fn new(per_second: NonZeroU32, burst: NonZeroU32, forced_keys: Option<String>) -> Self {
         let quota = Quota::per_second(per_second).allow_burst(burst);
         let limiter = Arc::new(governor::RateLimiter::dashmap(quota));
 
-        PartitionLimiter { limiter }
+        let forced_keys: HashSet<String> = match forced_keys {
+            None => HashSet::new(),
+            Some(values) => values.split(',').map(String::from).collect(),
+        };
+
+        PartitionLimiter { limiter, forced_keys }
     }
 
     pub fn is_limited(&self, key: &String) -> bool {
-        self.limiter.check_key(key).is_err()
+        self.forced_keys.contains(key) || self.limiter.check_key(key).is_err()
     }
 }
 
@@ -37,7 +44,7 @@ mod tests {
     #[tokio::test]
     async fn low_limits() {
         let limiter =
-            PartitionLimiter::new(NonZeroU32::new(1).unwrap(), NonZeroU32::new(1).unwrap());
+            PartitionLimiter::new(NonZeroU32::new(1).unwrap(), NonZeroU32::new(1).unwrap(), None);
         let token = String::from("test");
 
         assert!(!limiter.is_limited(&token));
@@ -47,12 +54,32 @@ mod tests {
     #[tokio::test]
     async fn bursting() {
         let limiter =
-            PartitionLimiter::new(NonZeroU32::new(1).unwrap(), NonZeroU32::new(3).unwrap());
+            PartitionLimiter::new(NonZeroU32::new(1).unwrap(), NonZeroU32::new(3).unwrap(), None);
         let token = String::from("test");
 
         assert!(!limiter.is_limited(&token));
         assert!(!limiter.is_limited(&token));
         assert!(!limiter.is_limited(&token));
         assert!(limiter.is_limited(&token));
+    }
+
+    #[tokio::test]
+    async fn forced_key() {
+        let key_one = String::from("one");
+        let key_two = String::from("two");
+        let key_three = String::from("three");
+        let forced_keys = Some(String::from("one,three"));
+
+        let limiter =
+            PartitionLimiter::new(NonZeroU32::new(1).unwrap(), NonZeroU32::new(1).unwrap(), forced_keys);
+
+        // One and three are limited from the start, two is not
+        assert!(limiter.is_limited(&key_one));
+        assert!(!limiter.is_limited(&key_two));
+        assert!(limiter.is_limited(&key_three));
+
+        // Two is limited on the second event
+        assert!(limiter.is_limited(&key_two));
+
     }
 }

--- a/capture/src/server.rs
+++ b/capture/src/server.rs
@@ -44,7 +44,11 @@ where
             .register("rdkafka".to_string(), Duration::seconds(30))
             .await;
 
-        let partition = PartitionLimiter::new(config.per_second_limit, config.burst_limit, config.overflow_forced_keys);
+        let partition = PartitionLimiter::new(
+            config.per_second_limit,
+            config.burst_limit,
+            config.overflow_forced_keys,
+        );
         let sink = sink::KafkaSink::new(config.kafka, sink_liveness, partition).unwrap();
 
         router::router(

--- a/capture/src/server.rs
+++ b/capture/src/server.rs
@@ -44,7 +44,7 @@ where
             .register("rdkafka".to_string(), Duration::seconds(30))
             .await;
 
-        let partition = PartitionLimiter::new(config.per_second_limit, config.burst_limit);
+        let partition = PartitionLimiter::new(config.per_second_limit, config.burst_limit, config.overflow_forced_keys);
         let sink = sink::KafkaSink::new(config.kafka, sink_liveness, partition).unwrap();
 
         router::router(

--- a/capture/src/sink.rs
+++ b/capture/src/sink.rs
@@ -301,8 +301,11 @@ mod tests {
         let handle = registry
             .register("one".to_string(), Duration::seconds(30))
             .await;
-        let limiter =
-            PartitionLimiter::new(NonZeroU32::new(10).unwrap(), NonZeroU32::new(10).unwrap());
+        let limiter = PartitionLimiter::new(
+            NonZeroU32::new(10).unwrap(),
+            NonZeroU32::new(10).unwrap(),
+            None,
+        );
         let cluster = MockCluster::new(1).expect("failed to create mock brokers");
         let config = config::KafkaConfig {
             kafka_producer_linger_ms: 0,


### PR DESCRIPTION
- Add the `overflow_forced_keys` config to mirror capture-py's `EVENT_PARTITION_KEYS_TO_OVERRIDE`, to force a key to overflow even if the burst threshold is not reached.
- Add unit test for that feature

`HashSet::contains` has a fast-path for empty state, so I'm just using a `HashSet::new()` by default. There are several hashing algorithms to choose from, but that's not a big concern right now.