### PR TITLE
fix: increment over_quota by batch size instead of 1

### DIFF
--- a/capture/src/capture.rs
+++ b/capture/src/capture.rs
@@ -88,7 +88,7 @@ pub async fn event(
         .await;
 
     if billing_limited {
-        report_dropped_events("over_quota", 1);
+        report_dropped_events("over_quota", events.len() as u64);
 
         // for v0 we want to just return ok 🙃
         // this is because the clients are pretty dumb and will just retry over and over and


### PR DESCRIPTION
When dropping data due to billing limits, we increment the `capture_events_dropped_total` counter by one per batch, instead of one per droped event.

This should explain the discrepancy we're seeing between `capture_events_received_total` and `capture_events_ingested_total`