### PR TITLE
account for process_events errors in capture_events_dropped_total and log them

### DIFF
--- a/capture/src/capture.rs
+++ b/capture/src/capture.rs
@@ -146,7 +146,7 @@ pub async fn event(
     if let Err(err) = process_events(state.sink.clone(), &events, &context).await {
         report_dropped_events("process_events_error", events.len() as u64);
         tracing::log::warn!("rejected invalid payload: {}", err);
-        return Err(err)
+        return Err(err);
     }
 
     Ok(Json(CaptureResponse {

--- a/capture/src/capture.rs
+++ b/capture/src/capture.rs
@@ -143,7 +143,11 @@ pub async fn event(
 
     tracing::debug!(context=?context, events=?events, "decoded request");
 
-    process_events(state.sink.clone(), &events, &context).await?;
+    if let Err(err) = process_events(state.sink.clone(), &events, &context).await {
+        report_dropped_events("process_events_error", events.len() as u64);
+        tracing::log::warn!("rejected invalid payload: {}", err);
+        return Err(err)
+    }
 
     Ok(Json(CaptureResponse {
         status: CaptureResponseCode::Ok,


### PR DESCRIPTION
We'll want to be less noisy after the rollout is done, but for the moment, let's account for 400s in the `capture_events_dropped_total` metric, to make sure we're not dropping them elsewhere.