### PR TITLE
properly process Kafka produce ACKs to propagate errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053adfa02fab06e86c01d586cc68aa47ee0ff4489a59469081dc12cbcde578bf"
+checksum = "d54f02a5a40220f8a2dfa47ddb38ba9064475a5807a69504b6f91711df2eea63"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -1549,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.6.0+2.2.0"
+version = "4.7.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad63c279fca41a27c231c450a2d2ad18288032e9cbb159ad16c9d96eba35aaaf"
+checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ uuid = { version = "1.3.3", features = ["serde"] }
 async-trait = "0.1.68"
 serde_urlencoded = "0.7.1"
 rand = "0.8.5"
-rdkafka = { version = "0.34", features = ["cmake-build", "ssl"] }
+rdkafka = { version = "0.36.0", features = ["cmake-build", "ssl"] }
 metrics = "0.21.1"
 metrics-exporter-prometheus = "0.12.1"
 thiserror = "1.0.48"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+resolver = "2"
+
 members = [
   "capture",
   "capture-server"

--- a/capture-server/tests/common.rs
+++ b/capture-server/tests/common.rs
@@ -32,6 +32,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     kafka: KafkaConfig {
         kafka_producer_linger_ms: 0, // Send messages as soon as possible
         kafka_producer_queue_mib: 10,
+        kafka_message_timeout_ms: 10000, // 10s, ACKs can be slow on low volumes
         kafka_compression_codec: "none".to_string(),
         kafka_hosts: "kafka:9092".to_string(),
         kafka_topic: "events_plugin_ingestion".to_string(),

--- a/capture-server/tests/common.rs
+++ b/capture-server/tests/common.rs
@@ -32,7 +32,7 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     kafka: KafkaConfig {
         kafka_producer_linger_ms: 0, // Send messages as soon as possible
         kafka_producer_queue_mib: 10,
-        kafka_message_timeout_ms: 10000, // 10s, ACKs can be slow on low volumes
+        kafka_message_timeout_ms: 10000, // 10s, ACKs can be slow on low volumes, should be tuned
         kafka_compression_codec: "none".to_string(),
         kafka_hosts: "kafka:9092".to_string(),
         kafka_topic: "events_plugin_ingestion".to_string(),

--- a/capture/src/capture.rs
+++ b/capture/src/capture.rs
@@ -228,11 +228,10 @@ pub async fn process_events<'a>(
     tracing::debug!(events=?events, "processed {} events", events.len());
 
     if events.len() == 1 {
-        sink.send(events[0].clone()).await?;
+        sink.send(events[0].clone()).await
     } else {
-        sink.send_batch(events).await?;
+        sink.send_batch(events).await
     }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/capture/src/config.rs
+++ b/capture/src/config.rs
@@ -35,6 +35,8 @@ pub struct KafkaConfig {
     pub kafka_producer_linger_ms: u32, // Maximum time between producer batches during low traffic
     #[envconfig(default = "400")]
     pub kafka_producer_queue_mib: u32, // Size of the in-memory producer queue in mebibytes
+    #[envconfig(default = "20000")]
+    pub kafka_message_timeout_ms: u32, // Time before we stop retrying producing a message: 20 seconds
     #[envconfig(default = "none")]
     pub kafka_compression_codec: String, // none, gzip, snappy, lz4, zstd
     pub kafka_hosts: String,

--- a/capture/src/server.rs
+++ b/capture/src/server.rs
@@ -45,7 +45,8 @@ where
             .await;
 
         let partition = PartitionLimiter::new(config.per_second_limit, config.burst_limit);
-        let sink = sink::KafkaSink::new(config.kafka, sink_liveness, partition).unwrap();
+        let sink = sink::KafkaSink::new(config.kafka, sink_liveness, partition)
+            .expect("failed to start Kafka sink");
 
         router::router(
             crate::time::SystemTime {},

--- a/capture/src/sink.rs
+++ b/capture/src/sink.rs
@@ -240,6 +240,7 @@ impl EventSink for KafkaSink {
         let limited = self.partition.is_limited(&event.key());
         let ack =
             Self::kafka_send(self.producer.clone(), self.topic.clone(), event, limited).await?;
+        histogram!("capture_event_batch_size", 1.0);
         Self::process_ack(ack).await
     }
 

--- a/capture/src/sink.rs
+++ b/capture/src/sink.rs
@@ -359,7 +359,7 @@ mod tests {
         cluster.clear_request_errors(RDKafkaApiKey::Produce);
         let err = [RDKafkaRespErr::RD_KAFKA_RESP_ERR_INVALID_PARTITIONS; 1];
         cluster.request_errors(RDKafkaApiKey::Produce, &err);
-        match sink.send(event.clone()).await {
+        match sink.send_batch(vec![event.clone(), event.clone()]).await {
             Err(CaptureError::RetryableSinkError) => {} // Expected
             Err(err) => panic!("wrong error code {}", err),
             Ok(()) => panic!("should have errored"),
@@ -384,6 +384,11 @@ mod tests {
         let err = [RDKafkaRespErr::RD_KAFKA_RESP_ERR_BROKER_NOT_AVAILABLE; 50];
         cluster.request_errors(RDKafkaApiKey::Produce, &err);
         match sink.send(event.clone()).await {
+            Err(CaptureError::RetryableSinkError) => {} // Expected
+            Err(err) => panic!("wrong error code {}", err),
+            Ok(()) => panic!("should have errored"),
+        };
+        match sink.send_batch(vec![event.clone(), event.clone()]).await {
             Err(CaptureError::RetryableSinkError) => {} // Expected
             Err(err) => panic!("wrong error code {}", err),
             Ok(()) => panic!("should have errored"),


### PR DESCRIPTION
- Make sure that we properly propagate produce errors, by awaiting on the `DeliveryPromise`
- Wrap error handling in `process_ack` for reuse between the two code paths
- Set a 20s message produce timeout, so that we can report produce errors before the client times out and closes the connection
- Add a unit test using a `MockCluster`