### PR TITLE
tracing: add ack_wait spans

### DIFF
--- a/capture/src/sink.rs
+++ b/capture/src/sink.rs
@@ -8,8 +8,8 @@ use rdkafka::producer::future_producer::{FutureProducer, FutureRecord};
 use rdkafka::producer::{DeliveryFuture, Producer};
 use rdkafka::util::Timeout;
 use tokio::task::JoinSet;
-use tracing::{instrument, span};
 use tracing::log::{debug, error, info};
+use tracing::{info_span, instrument, Instrument};
 
 use crate::api::CaptureError;
 use crate::config::KafkaConfig;
@@ -241,8 +241,9 @@ impl EventSink for KafkaSink {
         let ack =
             Self::kafka_send(self.producer.clone(), self.topic.clone(), event, limited).await?;
         histogram!("capture_event_batch_size", 1.0);
-        let ackSpan = span!(Level::INFO, "ack_wait_one").entered();
-        Self::process_ack(ack).await
+        Self::process_ack(ack)
+            .instrument(info_span!("ack_wait_one"))
+            .await
     }
 
     #[instrument(skip_all)]
@@ -262,22 +263,25 @@ impl EventSink for KafkaSink {
         }
 
         // Await on all the produce promises, fail batch on first failure
-        let ackSpan = span!(Level::INFO, "ack_wait_many").entered();
-        while let Some(res) = set.join_next().await {
-            match res {
-                Ok(Ok(_)) => {}
-                Ok(Err(err)) => {
-                    set.abort_all();
-                    return Err(err);
-                }
-                Err(err) => {
-                    set.abort_all();
-                    error!("join error while waiting on Kafka ACK: {:?}", err);
-                    return Err(CaptureError::RetryableSinkError);
+        async move {
+            while let Some(res) = set.join_next().await {
+                match res {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(err)) => {
+                        set.abort_all();
+                        return Err(err);
+                    }
+                    Err(err) => {
+                        set.abort_all();
+                        error!("join error while waiting on Kafka ACK: {:?}", err);
+                        return Err(CaptureError::RetryableSinkError);
+                    }
                 }
             }
+            Ok(())
         }
-        ackSpan.exit();
+        .instrument(info_span!("ack_wait_many"))
+        .await?;
 
         histogram!("capture_event_batch_size", batch_size as f64);
         Ok(())


### PR DESCRIPTION
Latency has increased an order of magnitude with the addition of the ACK wait. While I expected some increase, I'd like to confirm whether it's the main cause of the latency. Let's add an ad-hoc span around it.


Tested locally: 

![image](https://github.com/PostHog/capture/assets/6241083/38992856-990b-4ee6-aa18-4c62df96c98f)


![image](https://github.com/PostHog/capture/assets/6241083/8e61fae5-8857-457f-bf70-cd089be71c11)
