### PR TITLE
feat: trim distinct_id to 200 chars

### DIFF
--- a/capture-server/tests/events.rs
+++ b/capture-server/tests/events.rs
@@ -166,3 +166,44 @@ async fn it_does_not_partition_limit_different_ids() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn it_trims_distinct_id() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let distinct_id1 = random_string("id", 200 - 3);
+    let distinct_id2 = random_string("id", 200);
+    let (trimmed_distinct_id2, _) = distinct_id2.split_at(200); // works because ascii chars
+
+    let topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_topic(&topic);
+
+    let event = json!([{
+        "token": token,
+        "event": "event1",
+        "distinct_id": distinct_id1
+    },{
+        "token": token,
+        "event": "event2",
+        "distinct_id": distinct_id2
+    }]);
+    let res = server.capture_events(event.to_string()).await;
+    assert_eq!(StatusCode::OK, res.status());
+
+    assert_json_include!(
+        actual: topic.next_event()?,
+        expected: json!({
+            "token": token,
+            "distinct_id": distinct_id1
+        })
+    );
+    assert_json_include!(
+        actual: topic.next_event()?,
+        expected: json!({
+            "token": token,
+            "distinct_id": trimmed_distinct_id2
+        })
+    );
+
+    Ok(())
+}

--- a/capture-server/tests/events.rs
+++ b/capture-server/tests/events.rs
@@ -172,7 +172,7 @@ async fn it_trims_distinct_id() -> Result<()> {
     setup_tracing();
     let token = random_string("token", 16);
     let distinct_id1 = random_string("id", 200 - 3);
-    let distinct_id2 = random_string("id", 200);
+    let distinct_id2 = random_string("id", 222);
     let (trimmed_distinct_id2, _) = distinct_id2.split_at(200); // works because ascii chars
 
     let topic = EphemeralTopic::new().await;

--- a/capture/src/capture.rs
+++ b/capture/src/capture.rs
@@ -172,6 +172,12 @@ pub fn process_single_event(
             _ => return Err(CaptureError::MissingDistinctId),
         },
     };
+    // Limit the size of distinct_id to 200 chars
+    let distinct_id: String = match distinct_id.len() {
+        0..=200 => distinct_id.to_owned(),
+        _ => distinct_id.chars().take(200).collect(),
+    };
+
     if event.event.is_empty() {
         return Err(CaptureError::MissingEventName);
     }
@@ -183,7 +189,7 @@ pub fn process_single_event(
 
     Ok(ProcessedEvent {
         uuid: event.uuid.unwrap_or_else(uuid_v7),
-        distinct_id: distinct_id.to_string(),
+        distinct_id,
         ip: context.client_ip.clone(),
         data,
         now: context.now.clone(),


### PR DESCRIPTION
- capture.py does [trim distinct_ids to 200 characters](https://github.com/PostHog/posthog/blob/d7acdd6fa55a4f087fafa7339801057f3394cbfd/posthog/api/capture.py#L253), let's replicate it
- added integration test, as we don't really care about where the trimming happens