### PR TITLE
revert rdkafka to 0.34 to evaluate impact

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,7 @@ jobs:
 
   test:
     runs-on: buildjet-4vcpu-ubuntu-2204
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1549,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.7.0+2.3.0"
+version = "4.6.0+2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
+checksum = "ad63c279fca41a27c231c450a2d2ad18288032e9cbb159ad16c9d96eba35aaaf"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.36.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54f02a5a40220f8a2dfa47ddb38ba9064475a5807a69504b6f91711df2eea63"
+checksum = "053adfa02fab06e86c01d586cc68aa47ee0ff4489a59469081dc12cbcde578bf"
 dependencies = [
  "futures-channel",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ uuid = { version = "1.3.3", features = ["serde"] }
 async-trait = "0.1.68"
 serde_urlencoded = "0.7.1"
 rand = "0.8.5"
-rdkafka = { version = "0.36.0", features = ["cmake-build", "ssl"] }
+rdkafka = { version = "0.34.0", features = ["cmake-build", "ssl"] }
 metrics = "0.21.1"
 metrics-exporter-prometheus = "0.12.1"
 thiserror = "1.0.48"

--- a/capture-server/tests/common.rs
+++ b/capture-server/tests/common.rs
@@ -177,6 +177,7 @@ impl EphemeralTopic {
 impl Drop for EphemeralTopic {
     fn drop(&mut self) {
         debug!("dropping EphemeralTopic {}...", self.topic_name);
+        _ = self.consumer.unassign();
         self.consumer.unsubscribe();
         match futures::executor::block_on(timeout(
             Duration::from_secs(10),


### PR DESCRIPTION
https://github.com/PostHog/capture/pull/59 also bumped the rust-rdkafka crate from 0.34.0 to 0.36.0. As stated in [their changelog](https://github.com/fede1024/rust-rdkafka/blob/master/changelog.md), 0.36.0 is a pretty big rewrite, so there's a risk that our memory whoes come from there.

Let's revert this dependency for a day and evaluate impact on batch size and memory usage. We don't rely on fixes or new features from this version.