### PR TITLE
report partition_limits_key_count metric

### DIFF
--- a/capture/src/server.rs
+++ b/capture/src/server.rs
@@ -49,6 +49,12 @@ where
             config.burst_limit,
             config.overflow_forced_keys,
         );
+        if config.export_prometheus {
+            let partition = partition.clone();
+            tokio::spawn(async move {
+                partition.report_metrics().await;
+            });
+        }
         let sink = sink::KafkaSink::new(config.kafka, sink_liveness, partition)
             .expect("failed to start Kafka sink");
 


### PR DESCRIPTION
Another contenter for memory leak cause is governor's unbounded memory usage. Let's report the store size to prometheus, and check whether this metric correlates with the memory usage ramp-up.

If that's the case, we should call `self.limiter.retain_recent(); self.limiter.shrink_to_fit();` on a schedule to ignore old keys. Not doing this today, as I don't want to change two things at once, and we're rolling-back rdkafka too.